### PR TITLE
Adiciona Dockerfile e docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+go.work.sum
+
+# env file
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM golang:1.23.1
+# FROM golang:1.23.1-alpine
+
+WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.23.1
-# FROM golang:1.23.1-alpine
+FROM golang:1.22.5
 
 WORKDIR /app
+
+COPY main.go go.* /app/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,15 @@ services:
       - POSTGRES_DB=${DB_NAME}
     volumes:
       - postgres-db:/var/lib/postgresql/data
+  pgadmin:
+    image: dpage/pgadmin4
+    environment:
+      - PGADMIN_DEFAULT_EMAIL=${PGADMIN_DEFAULT_EMAIL}
+      - PGADMIN_DEFAULT_PASSWORD=${PGADMIN_DEFAULT_PASSWORD}
+    ports:
+      - "6543:80"
+    depends_on:
+      - db
 
 volumes:
   postgres-db:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     env_file:
       - .env
     ports:
-      - "3000:3000"
+      - "8080:8080"
     volumes:
       - .:/app
     command: go run ./main.go

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,23 @@
+services:
+  app:
+    build: .
+    env_file:
+      - .env
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/app
+    command: go run ./main.go
+  db:
+    image: postgres:alpine
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=${DB_USER}
+      - POSTGRES_PASSWORD=${DB_PASSWORD}
+      - POSTGRES_DB=${DB_NAME}
+    volumes:
+      - postgres-db:/var/lib/postgresql/data
+
+volumes:
+  postgres-db:


### PR DESCRIPTION
# Adiciona Dockerfile e docker-compose

- Adicionado Dockerfile para construir a aplicação Go
- Configurado docker-compose.yml para incluir:
  - Serviço da aplicação Go
  - Serviço do banco de dados PostgreSQL
  - Serviço do pgAdmin para gerenciamento do banco de dados
- Adicionado arquivo .gitignore
