### PR TITLE
Implementação da rota /publicacoes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/mentoriadevops/planet
 
 go 1.22.5
+
+require github.com/gorilla/mux v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=

--- a/main.go
+++ b/main.go
@@ -1,7 +1,32 @@
 package main
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+func handlePublicacoes(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-type", "application/json")
+
+	response := map[string]interface{}{
+		"message":     "Publicações",
+		"publicações": []string{"publicação 1", "publicação 2"},
+	}
+
+	json.NewEncoder(w).Encode(response)
+}
 
 func main() {
-	fmt.Println("Olá mundo!")
+
+	r := mux.NewRouter()
+	fmt.Println("Iniciando o servidor...")
+
+	r.HandleFunc("/publicacoes", handlePublicacoes).Methods("GET")
+
+	log.Fatal(http.ListenAndServe(":8080", r))
+
 }


### PR DESCRIPTION
Foi feita a implementação da rota /publicações no arquivo main.go, utilizando o pacote mux para roteamento. A rota responde com JSON simples. 